### PR TITLE
Add deployment to kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,14 @@ clean:
 check: server/cockpit-bridge-websocket-connector.pyz
 	python3 -m unittest discover -vs test
 
-.PHONY: containers run clean build
+k8s-clean:
+	oc delete -f webconsoleapp-k8s.yaml --ignore-not-found=true
+	oc get pods --selector app=webconsoleapp-session -o name | xargs -rn1 oc delete --force=true
+	oc delete -f webconsoleapp-k8s-buildconfig.yaml --ignore-not-found=true
+
+k8s-deploy: k8s-clean
+	oc create -f webconsoleapp-k8s-buildconfig.yaml
+	oc start-build build-webconsoleapp --follow
+	oc create -f webconsoleapp-k8s.yaml
+
+.PHONY: containers run clean build k8s-clean k8s-deploy

--- a/appservice/scripts/websocket-session.py
+++ b/appservice/scripts/websocket-session.py
@@ -12,10 +12,9 @@ logger = logging.getLogger(__name__)
 async def ws2out(ws):
     try:
         async for message in ws:
-            logger.debug('ws -> stdout: %s', message)
             os.write(1, message)
     except websockets.exceptions.ConnectionClosedError as e:
-        logger.debug('ws2out: websocket connection got closed: %s', e)
+        logger.info('ws2out: websocket connection got closed: %s', e)
         return
 
 
@@ -23,10 +22,9 @@ async def in2ws(reader, ws):
     while True:
         message = await reader.read(4096)
         if not message:
-            logger.debug('in -> ws: EOF')
+            logger.info('in -> ws: EOF')
             await ws.close()
             break
-        logger.debug('in -> ws: %s', message)
         await ws.send(message)
 
 
@@ -51,5 +49,5 @@ async def main():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     asyncio.run(main())

--- a/webconsoleapp-k8s-buildconfig.yaml
+++ b/webconsoleapp-k8s-buildconfig.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: webconsoleapp
+
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: build-webconsoleapp
+spec:
+  source:
+    type: Git
+    git:
+      uri: https://github.com/jelly/console.dot
+      # FIXME: drop after landing https://github.com/jelly/console.dot/pull/38
+      ref: k8s
+    contextDir: appservice
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: Containerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: webconsoleapp:latest

--- a/webconsoleapp-k8s.yaml
+++ b/webconsoleapp-k8s.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: v1
+# FIXME: turn into ReplicationController
+kind: Pod
+metadata:
+  name: webconsole-api
+  labels:
+    app: webconsole-api
+spec:
+  # FIXME: drop this for production
+  restartPolicy: Never
+  serviceAccountName: deployer
+  containers:
+    - name: front-end
+      # FIXME: hardcoded "cockpit-dev" project name
+      image: image-registry.openshift-image-registry.svc:5000/cockpit-dev/webconsoleapp:latest
+      #command: ["sleep", "infinity"]
+      env:
+        - name: API_URL
+          value: https://test.cloud.redhat.com
+        - name: SESSION_INSTANCE_DOMAIN
+          value: .webconsoleapp-sessions.cockpit-dev.svc.cluster.local
+      ports:
+        - containerPort: 8080
+          name: api
+
+---
+apiVersion: v1
+# FIXME: turn into ReplicationController
+kind: Pod
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  containers:
+    - name: redis
+      image: docker.io/redis
+      ports:
+        - containerPort: 6379
+          protocol: TCP
+          name: redis
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webconsole
+spec:
+  ports:
+  - name: api
+    targetPort: 8080
+    port: 8080
+    protocol: TCP
+  selector:
+    app: webconsole-api
+
+---
+# headless Service for session pod DNS
+apiVersion: v1
+kind: Service
+metadata:
+  name: webconsoleapp-sessions
+spec:
+  clusterIP: None
+  ports:
+  # unused, but must have one formally
+  - name: dummy
+    targetPort: 1234
+    port: 1234
+  selector:
+    app: webconsoleapp-session
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+  - name: redis
+    targetPort: 6379
+    port: 6379
+    protocol: TCP
+  selector:
+    app: redis


### PR DESCRIPTION
Teach appservice to create a k8s pod if it has k8s credentials. Add k8s
resource yaml to deploy the app. For development this uses singular pods
instead of ReplicationControllers.

 - [x] Builds on top of PR #37 
 - [x] Builds on top of PR #43
 - [x] Build on top of #46
 - [x] Rebase and re-test after the above two
 - [x] Add a `BuildConfig`, so that we don't have to push the webapp container to quay.io
 - [x] Add make targets
 - [x] Add documentation