### PR TITLE
appservice: Add session placeholder page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ This requires `podman` and `sscg` to be available on the host.
    make run
    ```
 
+ - Prepare some target machine on which you want to get a Cockpit session; this can just be a local VM.
+   It needs to have Cockpit ≥ 275 installed, at least the `cockpit-system` and `cockpit-bridge` packages.
+   You also need to copy `server/cockpit-bridge-websocket-connector.pyz` to the target machine (in the
+   final product this will be transmitted through Ansible):
+   ```
+   scp server/cockpit-bridge-websocket-connector.pyz target_machine:/tmp/
+   ```
+
  - Register a new session:
    ```
    curl -u admin:foobar --cacert 3scale/certs/ca.crt https://localhost:8443/api/webconsole/v1/sessions/new
@@ -37,13 +45,11 @@ This requires `podman` and `sscg` to be available on the host.
    {"id": "f835d542-b9ac-4329-a16a-b935036b4aa5"}
    ```
 
- - Pick some target machine/VM on which you want to get a Cockpit session; this can just be a local VM.
-   It needs to have Cockpit ≥ 275 installed, at least the `cockpit-system` and `cockpit-bridge` packages.
-   You also need to copy `server/cockpit-bridge-websocket-connector.pyz` to the target machine (in the
-   final product this will be transmitted through Ansible):
-   ```
-   scp server/cockpit-bridge-websocket-connector.pyz target_machine:/tmp/
-   ```
+ - Open the session in a browser:
+
+   https://localhost:8443/wss/webconsole/v1/sessions/SESSION_ID/web/
+
+   This is a stub page that waits until the target machine connects.
 
  - Connect the target machine to the ws session container. In a VM with a
    recent systemd nss-myhostname (like Fedora), you can use the `_gateway`
@@ -55,9 +61,7 @@ This requires `podman` and `sscg` to be available on the host.
    /tmp/cockpit-bridge-websocket-connector.pyz --basic-auth admin:foobar -k wss://_gateway:8443/wss/webconsole/v1/sessions/SESSION_ID/ws
    ```
 
- - Open Cockpit in a browser:
-
-   https://localhost:8443/wss/webconsole/v1/sessions/SESSION_ID/web/
+   This should cause the stub page to automatically reload, and show the actual Cockpit UI.
 
  - Clean up:
    ```
@@ -115,13 +119,13 @@ Both get deployed with
 
    It should be "wait_target".
 
-5. Now connect the target VM to the session pod:
+5. In the mitmproxy Firefox profile, open https://test.cloud.redhat.com/wss/webconsole/v1/sessions/SESSIONID/web/ to get the "waiting for target machine" stub page.
+
+6. Connect the target VM to the session pod:
 
       /tmp/cockpit-bridge-websocket-connector.pyz --basic-auth user:password -k wss://test.cloud.redhat.com/wss/webconsole/v1/sessions/SESSIONID/ws
 
-   Check the session status again, it should now be "running".
-
-6. In the mitmproxy Firefox profile, open https://test.cloud.redhat.com/wss/webconsole/v1/sessions/SESSIONID/web/ . You should now get a Cockpit UI for the user you started the bridge as.
+   You should now also get a Cockpit UI for the user you started the bridge as. If you check the session status again, it should be "running".
 
 You can run
 

--- a/appservice/closed-session.html
+++ b/appservice/closed-session.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Web Console</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Web Console</h1>
+
+    <p>The Web Console session ended. You can close this window now.</p>
+</body>
+</html>

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -27,7 +27,7 @@ SESSION_INSTANCE_DOMAIN = os.getenv('SESSION_INSTANCE_DOMAIN', '')
 PODMAN_SOCKET = '/run/podman/podman.sock'
 K8S_SERVICE_ACCOUNT = '/run/secrets/kubernetes.io/serviceaccount'
 
-# session_id → {state: wait_target or running, ip: session container address}
+# session_id → {status: wait_target or running, ip: session container address}
 SESSIONS: Dict[str, Dict[str, str]] = {}
 
 REDIS = redis.asyncio.Redis(host=os.environ['REDIS_SERVICE_HOST'],
@@ -146,7 +146,7 @@ async def handle_session_new(request):
                 continue
 
             logger.debug('session pod %s resolves to %s', session_hostname, addr)
-            SESSIONS[sessionid] = {'ip': addr, 'state': None}
+            SESSIONS[sessionid] = {'ip': addr, 'status': None}
             await update_session(sessionid, 'wait_target')
             response = JSONResponse({'id': sessionid})
             break

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -39,6 +39,8 @@ app = Starlette()
 
 with open(os.path.join(MY_DIR, 'wait-session.html')) as f:
     HTML_WAIT_SESSION = f.read()
+with open(os.path.join(MY_DIR, 'closed-session.html')) as f:
+    HTML_CLOSED_SESSION = f.read()
 
 
 @app.route(f'{config.ROUTE_API}/ping')
@@ -269,7 +271,9 @@ async def handle_session_id_http(upstream_req):
     session = SESSIONS.get(sessionid)
     if session is None:
         return PlainTextResponse('unknown session ID', status_code=404)
-    if session['status'] != 'running':
+    if session['status'] == 'closed':
+        return HTMLResponse(HTML_CLOSED_SESSION)
+    elif session['status'] != 'running':
         return HTMLResponse(HTML_WAIT_SESSION)
 
     target_url = f'http://{session["ip"]}:9090{upstream_req.url.path}'

--- a/appservice/wait-session.html
+++ b/appservice/wait-session.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Web Console</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Web Console</h1>
+
+    <p>Waiting for target system to connect. This may take some time...</p>
+
+    <p>Session status: <span id="session-status"></span></p>
+
+    <p id="error"></p>
+
+    <script type="text/javascript">
+        const API = document.URL.replace('/wss/', '/api/').replace(/\/web\/.*$/, '/');
+        const el_status = document.getElementById("session-status");
+        const el_error = document.getElementById("session-status");
+
+        async function callApiText(path) {
+            const response = await fetch(API + path);
+            return await response.text();
+        }
+
+        (async () => {
+            try {
+                // initial status
+                el_status.textContent = await callApiText('status');
+                // wait for running
+                await callApiText('wait-running');
+                el_status.textContent = "running; you will be redirected to the web console";
+                document.location.reload();
+            } catch (ex) {
+                el_error.textContent = JSON.stringify(ex);
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -134,7 +134,10 @@ class IntegrationTest(unittest.TestCase):
         subprocess.check_call(podman + cmd)
 
         # successful bridge connection updates status
-        self.wait_status(sessionid, b'running')
+        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/wait-running')
+        self.assertEqual(response.status, 200)
+        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/status')
+        self.assertEqual(response.read(), b'running')
 
         return sessionid
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -185,10 +185,9 @@ class IntegrationTest(unittest.TestCase):
         self.checkSession(s1)
         # second session is broken
         self.wait_status(s2, b'closed')
-        # ... and goes back to the placeholder page
+        # ... and goes to the "closed session" placeholder page
         response = self.request(f'{self.api_url}{config.ROUTE_WSS}/sessions/{s2}/web/')
-        # FIXME: this should handle "closed" differently
-        self.assertIn(b'Waiting for target system to connect', response.read())
+        self.assertIn(b'Web Console session ended', response.read())
 
         # can create a new session
         s3 = self.newSession()


### PR DESCRIPTION
Connecting to non-running sessions won't work and just cause a page
hang. Instead, show a stub page which waits for the session to go into
state "running", and then reloads itself to show cockpit.

Fixes #44
Fixes #50