### PR TITLE
Make /new a POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This requires `podman` and `sscg` to be available on the host.
 
  - Register a new session:
    ```
-   curl -u admin:foobar --cacert 3scale/certs/ca.crt https://localhost:8443/api/webconsole/v1/sessions/new
+   curl -X POST -u admin:foobar --cacert 3scale/certs/ca.crt https://localhost:8443/api/webconsole/v1/sessions/new
    ```
 
    This returns the session ID in a JSON object:
@@ -107,7 +107,7 @@ Both get deployed with
 
 4. Request a new session from the API:
 
-       curl -u user:password https://test.cloud.redhat.com/api/webconsole/v1/sessions/new
+       curl -X POST -u user:password https://test.cloud.redhat.com/api/webconsole/v1/sessions/new
 
    This will respond with a Session ID, like this:
 

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -123,7 +123,7 @@ spec:
         return response.status_code, response.text
 
 
-@app.route(f'{config.ROUTE_API}/sessions/new')
+@app.route(f'{config.ROUTE_API}/sessions/new', methods=['POST'])
 async def handle_session_new(request):
     global SESSIONS
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -73,13 +73,13 @@ class IntegrationTest(unittest.TestCase):
         request.add_header('Authorization', f'Basic {b64}')
         return request
 
-    def request(self, url, retries=0, timeout=1):
+    def request(self, url, retries=0, timeout=1, data=None):
         request = self.get_auth_request(url)
         tries = 0
         last_exc = None
         while tries <= retries:
             try:
-                response = urllib.request.urlopen(request, context=self.ssl_3scale, timeout=timeout)
+                response = urllib.request.urlopen(request, context=self.ssl_3scale, timeout=timeout, data=data)
                 if response.status >= 200 and response.status < 300:
                     return response
             except urllib.error.HTTPError as exc:
@@ -108,7 +108,7 @@ class IntegrationTest(unittest.TestCase):
             self.fail(f'session status was not updated to {expected_status}, still at {status}')
 
     def newSession(self, tag='stream9'):
-        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/new', timeout=10)
+        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/new', timeout=10, data=b'')
         self.assertEqual(response.status, 200)
         self.assertEqual(response.getheader('Content-Type'), 'application/json')
         sessionid = json.load(response)['id']


### PR DESCRIPTION
GET requests should be stateless and our specifcation also notes it should be a POST. In the tests a POST can be requested by specifying the data argument, this works the same as urllib's API. Specifying a data parameter automatically makes the request a POST. This will gives us flexibility for when in the future we need to send some data with a POST request.

Closes #31