### PR TITLE
test: Ensure that bridge connector picks up EOF

### DIFF
--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -140,7 +140,7 @@ class IntegrationTest(unittest.TestCase):
         subprocess.check_call(podman + cmd)
 
         # successful bridge connection updates status
-        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/wait-running')
+        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/wait-running', timeout=10)
         self.assertEqual(response.status, 200)
         response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/status')
         self.assertEqual(response.read(), b'running')


### PR DESCRIPTION
When the session pod dies or the Cockpit session ends, the bridge connector ought to pick up the EOF, close its end, and exit cleanly. Ensure that this happens by validating that the webconsoleserver container exists after crashing the session pod or timing out the cockpit session.

Give the server pods a predictable name for that. This also makes it easier to investigate failures, as session and server pods are now nicely grouped, instead of the latter having auto-generated random names.

Fixes #55