### PR TITLE
appservice: Add missing HTML files to container; refactor initialization

### DIFF
--- a/appservice/Containerfile
+++ b/appservice/Containerfile
@@ -8,7 +8,7 @@ RUN microdnf install --enablerepo=c9s --setopt=install_weak_deps=0 -y cockpit-ws
 
 RUN pip3 install redis starlette httpx websockets uvicorn
 
-COPY *.py /usr/local/bin/
+COPY *.py *.html /usr/local/bin/
 COPY scripts /
 
 CMD python3 /usr/local/bin/multiplexer.py


### PR DESCRIPTION
Our tests did not pick that up because they bind-mount the whole directory into the container. But that does not work on k8s.

Plus some refactoring which I intended to use for fixing #30 in an [initial attempt](https://github.com/cockpit-project/console.dot/commit/6826dc35bc363f633ce7c4a95e2eb04093a11110) -- but that doesn't work, and needs some more thinking. In the meantime, let's fix the container image! If you don't like the refactoring, I'm happy to drop it -- it's not immediately necessary any more.
