### PR TITLE
Managed machine authentication with TLS client cert

### DIFF
--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -25,9 +25,18 @@ http {
 
     server {
         listen 443 ssl;
-        ssl_certificate     /etc/nginx/certs/service-chain.pem;
-        ssl_certificate_key /etc/nginx/certs/service-key.pem;
         server_name localhost;
+
+        ssl_certificate        /etc/nginx/certs/service-chain.pem;
+        ssl_certificate_key    /etc/nginx/certs/service-key.pem;
+        ssl_client_certificate /etc/nginx/certs/ca.crt;
+        ssl_verify_client      optional;
+        auth_basic_user_file   /etc/nginx/.htpasswd;
+
+        # browsers connect with basic auth, managed machines with TLS auth; accept either
+        if ($ssl_client_verify = SUCCESS) { set $auth_basic off; }
+        if ($ssl_client_verify != SUCCESS) { set $auth_basic "Basic or TLS auth required"; }
+        auth_basic $auth_basic;
 
         # Prevent websocket access on /api
         location ~ ^/api/.*/cockpit/socket {
@@ -35,8 +44,6 @@ http {
         }
 
         location /wss/ {
-            auth_basic "Basic Auth required";
-            auth_basic_user_file /etc/nginx/.htpasswd;
             # Don't pass on proxy auth
             proxy_set_header Authorization "";
 
@@ -63,8 +70,6 @@ http {
         }
 
         location /api/ {
-            auth_basic "Basic Auth required";
-            auth_basic_user_file /etc/nginx/.htpasswd;
             # Don't pass on proxy auth
             proxy_set_header Authorization "";
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ PORT_3SCALE = 8443
 build: 3scale/certs/service-chain.pem server/cockpit-bridge-websocket-connector.pyz containers
 
 3scale/certs/service-chain.pem:
-	mkdir -p 3scale/certs && cd 3scale/certs && sscg --subject-alt-name localhost --subject-alt-name host.containers.internal
+	mkdir -p 3scale/certs
+	cd 3scale/certs && sscg --subject-alt-name localhost --subject-alt-name host.containers.internal \
+		--client-file=client.crt --client-key-file=client.key
 	cat 3scale/certs/service.pem 3scale/certs/ca.crt > $@
 
 # bundle https://pypi.org/project/websockets; it's packaged everywhere, but we

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ This requires `podman` and `sscg` to be available on the host.
 
  - Prepare some target machine on which you want to get a Cockpit session; this can just be a local VM.
    It needs to have Cockpit ≥ 275 installed, at least the `cockpit-system` and `cockpit-bridge` packages.
-   You also need to copy `server/cockpit-bridge-websocket-connector.pyz` to the target machine (in the
-   final product this will be transmitted through Ansible):
+   Copy `server/cockpit-bridge-websocket-connector.pyz` and the mock client certificate to the target machine
+   (in the final product the connector will be transmitted through Ansible, and use the actual RSHM cert):
    ```
-   scp server/cockpit-bridge-websocket-connector.pyz target_machine:/tmp/
+   scp server/cockpit-bridge-websocket-connector.pyz 3scale/certs/client.* target_machine:/tmp/
    ```
 
  - Register a new session:
@@ -58,7 +58,7 @@ This requires `podman` and `sscg` to be available on the host.
    `SESSION_ID` with the UUID that the `/new` call returned.
    Run this command as the user for which you want to get a Cockpit session:
    ```
-   /tmp/cockpit-bridge-websocket-connector.pyz --basic-auth admin:foobar -k wss://_gateway:8443/wss/webconsole/v1/sessions/SESSION_ID/ws
+   /tmp/cockpit-bridge-websocket-connector.pyz --tls-cert /tmp/client.crt --tls-key /tmp/client.key -k wss://_gateway:8443/wss/webconsole/v1/sessions/SESSION_ID/ws
    ```
 
    This should cause the stub page to automatically reload, and show the actual Cockpit UI.
@@ -123,7 +123,7 @@ Both get deployed with
 
 6. Connect the target VM to the session pod:
 
-      /tmp/cockpit-bridge-websocket-connector.pyz --basic-auth user:password -k wss://test.cloud.redhat.com/wss/webconsole/v1/sessions/SESSIONID/ws
+      /tmp/cockpit-bridge-websocket-connector.pyz --tls-cert /tmp/client.crt --tls-key /tmp/client.key -k wss://test.cloud.redhat.com/wss/webconsole/v1/sessions/SESSIONID/ws
 
    You should now also get a Cockpit UI for the user you started the bridge as. If you check the session status again, it should be "running".
 

--- a/server/cockpit-bridge-websocket-connector
+++ b/server/cockpit-bridge-websocket-connector
@@ -32,8 +32,15 @@ def parse_args():
                         help='Accept invalid certificates and hostnames while connecting to TLS')
     parser.add_argument('--basic-auth', metavar="USER:PASSWORD",
                         help='Authenticate with user/password (for testing)')
+    parser.add_argument('--tls-cert', metavar="PATH", help='Client TLS certificate')
+    parser.add_argument('--tls-key', metavar="PATH", help='Client TLS key')
     parser.add_argument('url', help='Connect to this ws:// or wss:// URL')
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if bool(args.tls_cert) != bool(args.tls_key):
+        parser.error('--tls-cert and --tls-key must both be given')
+
+    return args
 
 
 async def ws2bridge(ws, bridge_input):
@@ -69,6 +76,9 @@ async def bridge(args):
     if args.insecure:
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
+
+    if args.tls_cert:
+        ssl_context.load_cert_chain(args.tls_cert, args.tls_key)
 
     async with websockets.connect(args.url, extra_headers=headers, ssl=ssl_context) as websocket:
         p_bridge = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
This is a prerequisite for #45, and gets the mechanics and test bits in place. This is incomplete of course -- there is still no "org_id" in the certificate (but `sscg` can add an `--organization=` and other cert fields -- check how a real sub-man cert looks like!), nothing in our code even looks at the X-RH-Identity header, and our fake 3scale does not set the header either. But it already took me some non-trivial time to get these basics.

@jelly over to you for the rest, I figure.