### PR TITLE
workflows: Move to actions/checkout@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
           sudo apt-get install -y sscg flake8
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build containers and credentials
         run: make


### PR DESCRIPTION
v2 is deprecated.

---

See the warning that we get on workflow runs like https://github.com/cockpit-project/console.dot/actions/runs/3228147201

@marusak , @allisonkarlitskaya : FYI, we need to do this on *all* our projects eventually.