### PR TITLE
Add OpenAPI schema definition

### DIFF
--- a/appservice/Containerfile
+++ b/appservice/Containerfile
@@ -6,7 +6,7 @@ RUN microdnf install -y python3-pip iputils procps-ng && microdnf clean all
 RUN printf '[c9s]\nname = C9S\nbaseurl = http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os\ngpgcheck = 0\n' > /etc/yum.repos.d/c9s.repo
 RUN microdnf install --enablerepo=c9s --setopt=install_weak_deps=0 -y cockpit-ws cockpit-bridge && microdnf clean all
 
-RUN pip3 install redis starlette httpx websockets uvicorn
+RUN pip3 install redis starlette httpx websockets uvicorn pyyaml
 
 COPY *.py *.html /usr/local/bin/
 COPY scripts /

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -36,6 +36,7 @@ SCHEMAS = SchemaGenerator(
    {"openapi": "3.0.0", "info": {"title": "webconsole", "version": "1.0"}}
 )
 
+
 class Backend(enum.Enum):
     PODMAN = 0
     K8S = 1


### PR DESCRIPTION
The multiplexer now provides OpenAPI schema for public API endpoints. Starlette's API schema generator uses a mix of introspection and YAML in doc strings. The schema is available under `/api/webconsole/v1/schema` path and `python appservice/multiplexer.py schema` on the command line.

The SchemaGenerator introduces a new dependency on `pyyaml` package.

See: https://www.starlette.io/schemas/